### PR TITLE
refactor: replace tasks with db calls in hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "fastify": "^3.29.1",
-    "graasp-test": "github:graasp/graasp-test#25-item-type",
+    "graasp-test": "github:graasp/graasp-test",
     "husky": "7.0.4",
     "jest": "27.4.5",
     "prettier": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "tsc",
     "hooks:uninstall": "husky uninstall",
     "hooks:install": "husky install",
-    "pre-commit": "pretty-quick --staged && yarn lint",
+    "pre-commit": "yarn prettier:check && yarn lint",
     "prepare": "yarn build",
     "prepack": "yarn build",
     "prettier:check": "prettier --check \"{src,test}/**/*.ts\"",
@@ -19,7 +19,7 @@
     "lint": "eslint ."
   },
   "repository": "git@github.com:graasp/graasp-plugin-hidden-items.git",
-  "license": "AGPL",
+  "license": "AGPL-3.0-only",
   "bugs": {
     "url": "https://github.com/graasp/graasp-plugin-hidden-items/issues"
   },
@@ -40,11 +40,10 @@
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "fastify": "^3.29.1",
-    "graasp-test": "github:graasp/graasp-test",
+    "graasp-test": "github:graasp/graasp-test#25-item-type",
     "husky": "7.0.4",
     "jest": "27.4.5",
     "prettier": "2.5.1",
-    "pretty-quick": "3.1.2",
     "slonik": "26.1.0",
     "ts-jest": "27.0.7",
     "typescript": "4.4.4",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -39,6 +39,10 @@ const plugin: FastifyPluginAsync<GraaspHiddenOptions> = async (fastify, options)
   };
 
   const removeHiddenItems = async (items, actor) => {
+    if (!items || !items.length) {
+      return;
+    }
+
     // chunk items to run at maximum MAX_NB_TASKS_IN_PARALLEL
     const chunkedItems = spliceIntoChunks<Item>(
       items,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,6 +1,6 @@
 import { FastifyPluginAsync } from 'fastify';
 
-import { Actor, Item } from '@graasp/sdk';
+import { Actor, Item, spliceIntoChunks } from '@graasp/sdk';
 import { ItemTagService } from 'graasp-item-tags';
 
 import { CannotGetHiddenItemError, isGraaspError } from './utils';
@@ -8,6 +8,8 @@ import { CannotGetHiddenItemError, isGraaspError } from './utils';
 export interface GraaspHiddenOptions {
   hiddenTagId: string;
 }
+
+const MAX_NB_TASKS_IN_PARALLEL = 5;
 
 const plugin: FastifyPluginAsync<GraaspHiddenOptions> = async (fastify, options) => {
   const {
@@ -22,7 +24,9 @@ const plugin: FastifyPluginAsync<GraaspHiddenOptions> = async (fastify, options)
   const iTS = new ItemTagService();
 
   // Hide items for all users that don't have at least admin permission over it
+  // in parallel of a maximum of MAX_NB_TASKS_IN_PARALLEL parallel queries
   // avoid using tasks in hooks
+  // difficult to run one query for all items because hasTag and canAdmin don't have many-calls
   const isItemHidden = async (item: Item, actor: Actor) => {
     const isHidden = await iTS.hasTag(item, hiddenTagId, db.pool);
     let canAdmin = true;
@@ -34,6 +38,39 @@ const plugin: FastifyPluginAsync<GraaspHiddenOptions> = async (fastify, options)
     }
   };
 
+  const removeHiddenItems = async (items, actor) => {
+    // chunk items to run at maximum MAX_NB_TASKS_IN_PARALLEL
+    const chunkedItems = spliceIntoChunks<Item>(
+      items,
+      Math.ceil(items.length / MAX_NB_TASKS_IN_PARALLEL),
+    );
+
+    const filteredItems = (
+      await Promise.all(
+        chunkedItems.map(
+          // sequentially remove hidden items from chunk
+          async (chunkedItems) => {
+            const result = [];
+            for (const i of chunkedItems) {
+              try {
+                await isItemHidden(i, actor);
+                result.push(i);
+              } catch (err) {
+                if (!isGraaspError(err)) {
+                  throw err;
+                }
+              }
+            }
+            return result;
+          },
+        ),
+      )
+    ).flat();
+
+    // replace items in-place because we can't return a value from the handler
+    items.splice(0, items.length, ...filteredItems.filter(Boolean));
+  };
+
   runner.setTaskPostHookHandler<Item>(itemTaskManager.getGetTaskName(), async (item, actor) => {
     await isItemHidden(item, actor);
   });
@@ -41,66 +78,21 @@ const plugin: FastifyPluginAsync<GraaspHiddenOptions> = async (fastify, options)
   runner.setTaskPostHookHandler<Item[]>(
     itemTaskManager.getGetOwnTaskName(),
     async (items, actor) => {
-      const filteredItems = await Promise.all(
-        items.map(async (item) => {
-          try {
-            await isItemHidden(item, actor);
-            return item;
-          } catch (err) {
-            if (isGraaspError(err)) {
-              return null;
-            }
-            throw err;
-          }
-        }),
-      );
-
-      // Remove all hidden items in-place because we can't return a value from the handler
-      items.splice(0, items.length, ...filteredItems.filter(Boolean));
+      await removeHiddenItems(items, actor);
     },
   );
 
   runner.setTaskPostHookHandler<Item[]>(
     itemTaskManager.getGetSharedWithTaskName(),
     async (items, actor) => {
-      const filteredItems = await Promise.all(
-        items.map(async (item) => {
-          try {
-            await isItemHidden(item, actor);
-            return item;
-          } catch (err) {
-            if (isGraaspError(err)) {
-              return null;
-            }
-            throw err;
-          }
-        }),
-      );
-
-      // Remove all hidden items in-place because we can't return a value from the handler
-      items.splice(0, items.length, ...filteredItems.filter(Boolean));
+      await removeHiddenItems(items, actor);
     },
   );
 
   runner.setTaskPostHookHandler<Item[]>(
     itemTaskManager.getGetChildrenTaskName(),
     async (items, actor) => {
-      const filteredItems = await Promise.all(
-        items.map(async (item) => {
-          try {
-            await isItemHidden(item, actor);
-            return item;
-          } catch (err) {
-            if (isGraaspError(err)) {
-              return null;
-            }
-            throw err;
-          }
-        }),
-      );
-
-      // Remove all hidden items in-place because we can't return a value from the handler
-      items.splice(0, items.length, ...filteredItems.filter(Boolean));
+      await removeHiddenItems(items, actor);
     },
   );
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,24 @@
-import { GraaspError } from '@graasp/sdk';
+import { StatusCodes } from 'http-status-codes';
+
+import { ErrorFactory, GraaspError } from '@graasp/sdk';
+
+const PLUGIN_NAME = 'graasp-plugin-hidden-items';
 
 export const isGraaspError = (object: Error): object is GraaspError => {
   return 'origin' in object;
 };
+
+const GraaspHiddenItemError = ErrorFactory(PLUGIN_NAME);
+
+export class CannotGetHiddenItemError extends GraaspHiddenItemError {
+  constructor(data?: unknown) {
+    super(
+      {
+        code: 'GHIERR001',
+        statusCode: StatusCodes.FORBIDDEN,
+        message: 'Cannot read hidden item',
+      },
+      data,
+    );
+  }
+}

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -146,7 +146,7 @@ describe('test', () => {
       });
     });
 
-    it('Item with tag and less than admin should fail', async () => {
+    it('Item with tag and less than admin should return no item', async () => {
       const items = [ITEM_FOLDER, ITEM_FILE];
       mockCreateGetOfItemTask([{ tagId: HIDDEN_ITEM_TAG_ID, itemPath: ITEM_FILE.path }]);
       mockCreateGetMemberItemMembershipTask({});

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,16 +1,31 @@
 import { FastifyLoggerInstance } from 'fastify';
 
+import { ItemMembershipService } from '@graasp/sdk';
+import { ItemTagService } from 'graasp-item-tags';
 import { ItemMembershipTaskManager, ItemTaskManager, TaskRunner } from 'graasp-test';
 
+import { CannotGetHiddenItemError } from '../src/utils';
 import build from './app';
-import { ERROR, GRAASP_ACTOR, HIDDEN_ITEM_TAG_ID, ITEM_FILE, ITEM_FOLDER } from './constants';
+import { GRAASP_ACTOR, HIDDEN_ITEM_TAG_ID, ITEM_FILE, ITEM_FOLDER } from './constants';
 import { mockCreateGetMemberItemMembershipTask, mockCreateGetOfItemTask } from './mocks';
 
 const itemTaskManager = new ItemTaskManager();
 const itemMembershipTaskManager = new ItemMembershipTaskManager();
+const itemMembershipService = {
+  canAdmin: jest.fn(),
+} as unknown as ItemMembershipService;
 const runner = new TaskRunner();
 const actor = GRAASP_ACTOR;
 const MOCK_LOGGER = {} as unknown as FastifyLoggerInstance;
+
+const mockIsItemHiddenFn = ({ hasTag, canAdmin }) => {
+  jest.spyOn(ItemTagService.prototype, 'hasTag').mockImplementation(async () => {
+    return hasTag;
+  });
+  itemMembershipService.canAdmin = jest.fn().mockImplementation(async () => {
+    return canAdmin;
+  });
+};
 
 describe('test', () => {
   beforeEach(() => {
@@ -22,18 +37,10 @@ describe('test', () => {
   describe('getGetTaskName setTaskPostHookHandler', () => {
     it('Item without tag should success', async () => {
       const item = ITEM_FILE;
-      mockCreateGetOfItemTask([]);
-      mockCreateGetMemberItemMembershipTask({});
 
       jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(async (name, fn) => {
         if (name === itemTaskManager.getGetTaskName()) {
-          jest
-            .spyOn(TaskRunner.prototype, 'runSingleSequence')
-            .mockImplementation(async (tasks) => {
-              tasks[1].getInput?.();
-              expect(tasks[1].skip).toBeTruthy();
-              return true;
-            });
+          mockIsItemHiddenFn({ hasTag: false, canAdmin: true });
           expect(await fn(item, actor, { log: MOCK_LOGGER })).resolves;
         }
       });
@@ -41,6 +48,7 @@ describe('test', () => {
       await build({
         itemTaskManager,
         runner,
+        itemMembershipService,
         itemMembershipTaskManager,
         options: { hiddenTagId: HIDDEN_ITEM_TAG_ID },
       });
@@ -53,13 +61,7 @@ describe('test', () => {
 
       jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(async (name, fn) => {
         if (name === itemTaskManager.getGetTaskName()) {
-          jest
-            .spyOn(TaskRunner.prototype, 'runSingleSequence')
-            .mockImplementation(async (tasks) => {
-              tasks[1].getInput?.();
-              expect(tasks[1].skip).toBeFalsy();
-              return true;
-            });
+          mockIsItemHiddenFn({ hasTag: true, canAdmin: true });
           expect(await fn(item, actor, { log: MOCK_LOGGER })).resolves;
         }
       });
@@ -67,6 +69,7 @@ describe('test', () => {
       await build({
         itemTaskManager,
         runner,
+        itemMembershipService,
         itemMembershipTaskManager,
         options: { hiddenTagId: HIDDEN_ITEM_TAG_ID },
       });
@@ -79,20 +82,17 @@ describe('test', () => {
 
       jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(async (name, fn) => {
         if (name === itemTaskManager.getGetTaskName()) {
-          jest
-            .spyOn(TaskRunner.prototype, 'runSingleSequence')
-            .mockImplementation(async (tasks) => {
-              tasks[1].getInput?.();
-              expect(tasks[1].skip).toBeFalsy();
-              throw ERROR;
-            });
+          mockIsItemHiddenFn({ hasTag: true, canAdmin: false });
 
-          expect(fn(item, actor, { log: MOCK_LOGGER })).rejects.toEqual(ERROR);
+          expect(fn(item, actor, { log: MOCK_LOGGER })).rejects.toEqual(
+            new CannotGetHiddenItemError(ITEM_FILE.id),
+          );
         }
       });
 
       await build({
         itemTaskManager,
+        itemMembershipService,
         runner,
         itemMembershipTaskManager,
         options: { hiddenTagId: HIDDEN_ITEM_TAG_ID },
@@ -108,13 +108,7 @@ describe('test', () => {
 
       jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(async (name, fn) => {
         if (name === itemTaskManager.getGetOwnTaskName()) {
-          jest
-            .spyOn(TaskRunner.prototype, 'runSingleSequence')
-            .mockImplementation(async (tasks) => {
-              tasks[1].getInput?.();
-              expect(tasks[1].skip).toBeTruthy();
-              return true;
-            });
+          mockIsItemHiddenFn({ hasTag: false, canAdmin: true });
           expect(await fn(items, actor, { log: MOCK_LOGGER })).resolves;
           expect(items).toEqual([ITEM_FOLDER, ITEM_FILE]);
         }
@@ -123,6 +117,7 @@ describe('test', () => {
       await build({
         itemTaskManager,
         runner,
+        itemMembershipService,
         itemMembershipTaskManager,
         options: { hiddenTagId: HIDDEN_ITEM_TAG_ID },
       });
@@ -135,13 +130,7 @@ describe('test', () => {
 
       jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(async (name, fn) => {
         if (name === itemTaskManager.getGetOwnTaskName()) {
-          jest
-            .spyOn(TaskRunner.prototype, 'runSingleSequence')
-            .mockImplementation(async (tasks) => {
-              tasks[1].getInput?.();
-              expect(tasks[1].skip).toBeFalsy();
-              return true;
-            });
+          mockIsItemHiddenFn({ hasTag: true, canAdmin: true });
           expect(await fn(items, actor, { log: MOCK_LOGGER })).resolves;
           expect(items).toEqual([ITEM_FOLDER, ITEM_FILE]);
           done();
@@ -151,6 +140,7 @@ describe('test', () => {
       build({
         itemTaskManager,
         runner,
+        itemMembershipService,
         itemMembershipTaskManager,
         options: { hiddenTagId: HIDDEN_ITEM_TAG_ID },
       });
@@ -163,13 +153,7 @@ describe('test', () => {
 
       jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(async (name, fn) => {
         if (name === itemTaskManager.getGetOwnTaskName()) {
-          jest
-            .spyOn(TaskRunner.prototype, 'runSingleSequence')
-            .mockImplementation(async (tasks) => {
-              tasks[1].getInput?.();
-              expect(tasks[1].skip).toBeFalsy();
-              throw ERROR;
-            });
+          mockIsItemHiddenFn({ hasTag: true, canAdmin: false });
           expect(await fn(items, actor, { log: MOCK_LOGGER })).resolves;
           expect([]).toEqual(items);
         }
@@ -178,13 +162,14 @@ describe('test', () => {
       await build({
         itemTaskManager,
         runner,
+        itemMembershipService,
         itemMembershipTaskManager,
         options: { hiddenTagId: HIDDEN_ITEM_TAG_ID },
       });
     });
   });
 
-  describe('getGetSharedWithTaskName setTaskPostHookHandler', () => {
+  describe('getGetSharedWithTaskName postHook', () => {
     it('Items without tag should success', async () => {
       const items = [ITEM_FOLDER, ITEM_FILE];
       mockCreateGetOfItemTask([]);
@@ -192,13 +177,7 @@ describe('test', () => {
 
       jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(async (name, fn) => {
         if (name === itemTaskManager.getGetSharedWithTaskName()) {
-          jest
-            .spyOn(TaskRunner.prototype, 'runSingleSequence')
-            .mockImplementation(async (tasks) => {
-              tasks[1].getInput?.();
-              expect(tasks[1].skip).toBeTruthy();
-              return true;
-            });
+          mockIsItemHiddenFn({ hasTag: false, canAdmin: false });
           expect(await fn(items, actor, { log: MOCK_LOGGER })).resolves;
           expect(items).toEqual([ITEM_FOLDER, ITEM_FILE]);
         }
@@ -207,6 +186,7 @@ describe('test', () => {
       await build({
         itemTaskManager,
         runner,
+        itemMembershipService,
         itemMembershipTaskManager,
         options: { hiddenTagId: HIDDEN_ITEM_TAG_ID },
       });
@@ -219,13 +199,7 @@ describe('test', () => {
 
       jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(async (name, fn) => {
         if (name === itemTaskManager.getGetSharedWithTaskName()) {
-          jest
-            .spyOn(TaskRunner.prototype, 'runSingleSequence')
-            .mockImplementation(async (tasks) => {
-              tasks[1].getInput?.();
-              expect(tasks[1].skip).toBeFalsy();
-              return true;
-            });
+          mockIsItemHiddenFn({ hasTag: true, canAdmin: true });
           expect(await fn(items, actor, { log: MOCK_LOGGER })).resolves;
           expect(items).toEqual([ITEM_FOLDER, ITEM_FILE]);
         }
@@ -234,6 +208,7 @@ describe('test', () => {
       await build({
         itemTaskManager,
         runner,
+        itemMembershipService,
         itemMembershipTaskManager,
         options: { hiddenTagId: HIDDEN_ITEM_TAG_ID },
       });
@@ -246,13 +221,7 @@ describe('test', () => {
 
       jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(async (name, fn) => {
         if (name === itemTaskManager.getGetSharedWithTaskName()) {
-          jest
-            .spyOn(TaskRunner.prototype, 'runSingleSequence')
-            .mockImplementation(async (tasks) => {
-              tasks[1].getInput?.();
-              expect(tasks[1].skip).toBeFalsy();
-              throw ERROR;
-            });
+          mockIsItemHiddenFn({ hasTag: true, canAdmin: false });
           expect(await fn(items, actor, { log: MOCK_LOGGER })).resolves;
           expect(items).toEqual([]);
         }
@@ -261,13 +230,14 @@ describe('test', () => {
       await build({
         itemTaskManager,
         runner,
+        itemMembershipService,
         itemMembershipTaskManager,
         options: { hiddenTagId: HIDDEN_ITEM_TAG_ID },
       });
     });
   });
 
-  describe('getGetChildrenTaskName setTaskPostHookHandler', () => {
+  describe('getGetChildrenTaskName PostHook', () => {
     it('Items without tag should success', async () => {
       const items = [ITEM_FOLDER, ITEM_FILE];
       mockCreateGetOfItemTask([]);
@@ -275,13 +245,7 @@ describe('test', () => {
 
       jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(async (name, fn) => {
         if (name === itemTaskManager.getGetChildrenTaskName()) {
-          jest
-            .spyOn(TaskRunner.prototype, 'runSingleSequence')
-            .mockImplementation(async (tasks) => {
-              tasks[1].getInput?.();
-              expect(tasks[1].skip).toBeTruthy();
-              return true;
-            });
+          mockIsItemHiddenFn({ hasTag: false, canAdmin: false });
           expect(await fn(items, actor, { log: MOCK_LOGGER })).resolves;
           expect(items).toEqual([ITEM_FOLDER, ITEM_FILE]);
         }
@@ -290,6 +254,7 @@ describe('test', () => {
       await build({
         itemTaskManager,
         runner,
+        itemMembershipService,
         itemMembershipTaskManager,
         options: { hiddenTagId: HIDDEN_ITEM_TAG_ID },
       });
@@ -302,13 +267,7 @@ describe('test', () => {
 
       jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(async (name, fn) => {
         if (name === itemTaskManager.getGetChildrenTaskName()) {
-          jest
-            .spyOn(TaskRunner.prototype, 'runSingleSequence')
-            .mockImplementation(async (tasks) => {
-              tasks[1].getInput?.();
-              expect(tasks[1].skip).toBeFalsy();
-              return true;
-            });
+          mockIsItemHiddenFn({ hasTag: true, canAdmin: true });
           expect(await fn(items, actor, { log: MOCK_LOGGER })).resolves;
           expect(items).toEqual([ITEM_FOLDER, ITEM_FILE]);
         }
@@ -317,6 +276,7 @@ describe('test', () => {
       await build({
         itemTaskManager,
         runner,
+        itemMembershipService,
         itemMembershipTaskManager,
         options: { hiddenTagId: HIDDEN_ITEM_TAG_ID },
       });
@@ -329,13 +289,7 @@ describe('test', () => {
 
       jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(async (name, fn) => {
         if (name === itemTaskManager.getGetChildrenTaskName()) {
-          jest
-            .spyOn(TaskRunner.prototype, 'runSingleSequence')
-            .mockImplementation(async (tasks) => {
-              tasks[1].getInput?.();
-              expect(tasks[1].skip).toBeFalsy();
-              throw ERROR;
-            });
+          mockIsItemHiddenFn({ hasTag: true, canAdmin: false });
           expect(await fn(items, actor, { log: MOCK_LOGGER })).resolves;
           expect(items).toEqual([]);
         }
@@ -344,6 +298,7 @@ describe('test', () => {
       await build({
         itemTaskManager,
         runner,
+        itemMembershipService,
         itemMembershipTaskManager,
         options: { hiddenTagId: HIDDEN_ITEM_TAG_ID },
       });

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -34,7 +34,7 @@ describe('test', () => {
     jest.spyOn(runner, 'setTaskPreHookHandler').mockImplementation(async () => false);
   });
 
-  describe('getGetTaskName setTaskPostHookHandler', () => {
+  describe('getGetTaskName PostHook', () => {
     it('Item without tag should success', async () => {
       const item = ITEM_FILE;
 
@@ -156,6 +156,28 @@ describe('test', () => {
           mockIsItemHiddenFn({ hasTag: true, canAdmin: false });
           expect(await fn(items, actor, { log: MOCK_LOGGER })).resolves;
           expect([]).toEqual(items);
+        }
+      });
+
+      await build({
+        itemTaskManager,
+        runner,
+        itemMembershipService,
+        itemMembershipTaskManager,
+        options: { hiddenTagId: HIDDEN_ITEM_TAG_ID },
+      });
+    });
+
+    it('Empty items should continue', async () => {
+      const items = [];
+      mockCreateGetOfItemTask([]);
+      mockCreateGetMemberItemMembershipTask({});
+
+      jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(async (name, fn) => {
+        if (name === itemTaskManager.getGetOwnTaskName()) {
+          mockIsItemHiddenFn({ hasTag: false, canAdmin: true });
+          expect(await fn(items, actor, { log: MOCK_LOGGER })).resolves;
+          expect(items).toEqual([]);
         }
       });
 

--- a/test/app.ts
+++ b/test/app.ts
@@ -1,6 +1,12 @@
 import fastify from 'fastify';
 
-import { Item, ItemMembershipTaskManager, TaskRunner } from '@graasp/sdk';
+import {
+  DatabaseTransactionHandler,
+  Item,
+  ItemMembershipService,
+  ItemMembershipTaskManager,
+  TaskRunner,
+} from '@graasp/sdk';
 import { ItemTaskManager } from 'graasp-test';
 
 import plugin, { GraaspHiddenOptions } from '../src/plugin';
@@ -10,11 +16,13 @@ const build = async ({
   runner,
   itemTaskManager,
   itemMembershipTaskManager,
+  itemMembershipService,
   options,
 }: {
   runner: TaskRunner<Item>;
   itemTaskManager: ItemTaskManager;
   itemMembershipTaskManager: ItemMembershipTaskManager;
+  itemMembershipService: ItemMembershipService;
   options?: GraaspHiddenOptions;
 }) => {
   const app = fastify();
@@ -26,6 +34,10 @@ const build = async ({
   });
   app.decorate('itemMemberships', {
     taskManager: itemMembershipTaskManager,
+    dbService: itemMembershipService,
+  });
+  app.decorate('db', {
+    pool: {} as unknown as DatabaseTransactionHandler,
   });
 
   await app.register(plugin, options);

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -1,22 +1,15 @@
 import { v4 } from 'uuid';
 
-import { Actor, Item } from '@graasp/sdk';
-
-import { MockGraaspError } from './mocks';
+import { Actor, Item, ItemType } from '@graasp/sdk';
 
 export const HIDDEN_ITEM_TAG_ID = 'hiddenTagId';
-export const ERROR = new MockGraaspError({
-  code: 'GR000',
-  statusCode: 500,
-  message: 'Member cannot write item',
-});
 
 export const ITEM_FILE: Item = {
   id: v4(),
   description: '',
   path: 'some_path',
   name: 'item-file',
-  type: 'file',
+  type: ItemType.LOCAL_FILE,
   extra: {
     file: {},
   },
@@ -34,7 +27,7 @@ export const ITEM_FOLDER: Item = {
   description: '',
   path: 'some_folder_path',
   name: 'item-folder',
-  type: 'folder',
+  type: ItemType.FOLDER,
   extra: {},
   creator: 'creator-id',
   createdAt: 'somedata',
@@ -56,7 +49,7 @@ export const ITEMS: Item[] = [
     description: '',
     path: 'some_folder_path_1',
     name: 'item-folder',
-    type: 'folder',
+    type: ItemType.FOLDER,
     extra: {},
     creator: 'creator-id',
     createdAt: 'somedata',
@@ -71,7 +64,7 @@ export const ITEMS: Item[] = [
     description: '',
     path: 'some_folder_path_2',
     name: 'item-folder',
-    type: 'folder',
+    type: ItemType.FOLDER,
     extra: {},
     creator: 'creator-id',
     createdAt: 'somedata',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3432,7 +3432,7 @@ graasp-item-tags@graasp/graasp-item-tags:
     eslint-config-prettier: ^8.3.0
     fastify: ^3.29.1
     graasp-item-tags: graasp/graasp-item-tags
-    graasp-test: "github:graasp/graasp-test#25-item-type"
+    graasp-test: "github:graasp/graasp-test"
     husky: 7.0.4
     jest: 27.4.5
     prettier: 2.5.1
@@ -3443,9 +3443,9 @@ graasp-item-tags@graasp/graasp-item-tags:
   languageName: unknown
   linkType: soft
 
-"graasp-test@github:graasp/graasp-test#25-item-type":
+"graasp-test@github:graasp/graasp-test":
   version: 0.1.0
-  resolution: "graasp-test@https://github.com/graasp/graasp-test.git#commit=2f3a238506012be0da80b5ac899b4e13dd4c887d"
+  resolution: "graasp-test@https://github.com/graasp/graasp-test.git#commit=dd6ca72cf4be7483c9232f99d17186e7c441c601"
   dependencies:
     uuid: 8.3.2
   checksum: e4fcc3e4a9434bb590f26610c3d2bdff4f493e4b9257e947eb485649580acbccad4cf100f9335fe1f061b89bbe1209a1bea0ce5d5337af5f1ed6c619915d669f

--- a/yarn.lock
+++ b/yarn.lock
@@ -919,17 +919,18 @@ __metadata:
 
 "@graasp/sdk@github:graasp/graasp-sdk":
   version: 0.1.0
-  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=7e3491095507f6dfd129d318a87e6c63f0eb486e"
+  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=4fa31e8d473b13bfa0bad3e10da9e7b9ca4f20d5"
   dependencies:
     "@fastify/secure-session": 5.2.0
     aws-sdk: 2.1111.0
     fastify: ^3.29.1
     fluent-json-schema: 3.1.0
+    immutable: 4.1.0
     js-cookie: 3.0.1
     qs: 6.11.0
     slonik: 28.1.1
     uuid: 8.3.2
-  checksum: 1fdf3b5c52945769005bb6a83620a09f8995f5d16b2115675a7cf745b2a02e07758b3ed1a77b9357b0a9d6ab984e5427a18e4a5353e04f4d02ce16c2010e9785
+  checksum: 9af6a948678de50d9ae48792982e340d9aafd20e528185b4d34f8e54df7374573d011843741faabf5197cb8d73cf2fbadf033998937a313ceed61295f013dbc8
   languageName: node
   linkType: hard
 
@@ -1395,13 +1396,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/minimatch@npm:^3.0.3":
-  version: 3.0.5
-  resolution: "@types/minimatch@npm:3.0.5"
-  checksum: c41d136f67231c3131cf1d4ca0b06687f4a322918a3a5adddc87ce90ed9dbd175a3610adee36b106ae68c0b92c637c35e02b58c8a56c424f71d30993ea220b92
-  languageName: node
-  linkType: hard
-
 "@types/minimist@npm:^1.2.0":
   version: 1.2.2
   resolution: "@types/minimist@npm:1.2.2"
@@ -1803,13 +1797,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-differ@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "array-differ@npm:3.0.0"
-  checksum: 117edd9df5c1530bd116c6e8eea891d4bd02850fd89b1b36e532b6540e47ca620a373b81feca1c62d1395d9ae601516ba538abe5e8172d41091da2c546b05fb7
-  languageName: node
-  linkType: hard
-
 "array-ify@npm:^1.0.0":
   version: 1.0.0
   resolution: "array-ify@npm:1.0.0"
@@ -1828,13 +1815,6 @@ __metadata:
   version: 1.0.1
   resolution: "arrify@npm:1.0.1"
   checksum: 745075dd4a4624ff0225c331dacb99be501a515d39bcb7c84d24660314a6ec28e68131b137e6f7e16318170842ce97538cd298fc4cd6b2cc798e0b957f2747e7
-  languageName: node
-  linkType: hard
-
-"arrify@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "arrify@npm:2.0.1"
-  checksum: 067c4c1afd182806a82e4c1cb8acee16ab8b5284fbca1ce29408e6e91281c36bb5b612f6ddfbd40a0f7a7e0c75bf2696eb94c027f6e328d6e9c52465c98e4209
   languageName: node
   linkType: hard
 
@@ -2212,16 +2192,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "chalk@npm:3.0.0"
-  dependencies:
-    ansi-styles: ^4.1.0
-    supports-color: ^7.1.0
-  checksum: 8e3ddf3981c4da405ddbd7d9c8d91944ddf6e33d6837756979f7840a29272a69a5189ecae0ff84006750d6d1e92368d413335eab4db5476db6e6703a1d1e0505
-  languageName: node
-  linkType: hard
-
 "chalk@npm:^4.0.0":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
@@ -2458,7 +2428,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -2688,15 +2658,6 @@ __metadata:
   dependencies:
     iconv-lite: ^0.6.2
   checksum: bb98632f8ffa823996e508ce6a58ffcf5856330fde839ae42c9e1f436cc3b5cc651d4aeae72222916545428e54fd0f6aa8862fd8d25bdbcc4589f1e3f3715e7f
-  languageName: node
-  linkType: hard
-
-"end-of-stream@npm:^1.1.0":
-  version: 1.4.4
-  resolution: "end-of-stream@npm:1.4.4"
-  dependencies:
-    once: ^1.4.0
-  checksum: 530a5a5a1e517e962854a31693dbb5c0b2fc40b46dad2a56a2deec656ca040631124f4795823acc68238147805f8b021abbe221f4afed5ef3c8e8efc2024908b
   languageName: node
   linkType: hard
 
@@ -2962,23 +2923,6 @@ __metadata:
   version: 1.1.1
   resolution: "events@npm:1.1.1"
   checksum: 40431eb005cc4c57861b93d44c2981a49e7feb99df84cf551baed299ceea4444edf7744733f6a6667e942af687359b1f4a87ec1ec4f21d5127dac48a782039b9
-  languageName: node
-  linkType: hard
-
-"execa@npm:^4.0.0":
-  version: 4.1.0
-  resolution: "execa@npm:4.1.0"
-  dependencies:
-    cross-spawn: ^7.0.0
-    get-stream: ^5.0.0
-    human-signals: ^1.1.1
-    is-stream: ^2.0.0
-    merge-stream: ^2.0.0
-    npm-run-path: ^4.0.0
-    onetime: ^5.1.0
-    signal-exit: ^3.0.2
-    strip-final-newline: ^2.0.0
-  checksum: e30d298934d9c52f90f3847704fd8224e849a081ab2b517bbc02f5f7732c24e56a21f14cb96a08256deffeb2d12b2b7cb7e2b014a12fb36f8d3357e06417ed55
   languageName: node
   linkType: hard
 
@@ -3369,15 +3313,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^5.0.0":
-  version: 5.2.0
-  resolution: "get-stream@npm:5.2.0"
-  dependencies:
-    pump: ^3.0.0
-  checksum: 8bc1a23174a06b2b4ce600df38d6c98d2ef6d84e020c1ddad632ad75bac4e092eeb40e4c09e0761c35fc2dbc5e7fff5dab5e763a383582c4a167dd69a905bd12
-  languageName: node
-  linkType: hard
-
 "get-stream@npm:^6.0.0":
   version: 6.0.1
   resolution: "get-stream@npm:6.0.1"
@@ -3473,10 +3408,10 @@ __metadata:
 
 graasp-item-tags@graasp/graasp-item-tags:
   version: 0.1.0
-  resolution: "graasp-item-tags@https://github.com/graasp/graasp-item-tags.git#commit=fab30bc3e195ad1c156ea90754584988426f8a75"
+  resolution: "graasp-item-tags@https://github.com/graasp/graasp-item-tags.git#commit=c21f5e454b939928298590b41c25055aab8b9151"
   dependencies:
     http-status-codes: 2.2.0
-  checksum: 6b3093f6f5776c96e8a19f2dd712a5f35eec2ce4d20c5a9b89f1855842f0b79c5804cdd9637a81a690af216afc36419b51c357b408adb44d51454b45b63966ef
+  checksum: 89d2bf31538b1d0e342e364aaef8ba1f0198deef7323506be52bc72247afc078b00cae538c889995161935849c34e9a8c751a11c3defeb4e57a476ccccf801ca
   languageName: node
   linkType: hard
 
@@ -3497,11 +3432,10 @@ graasp-item-tags@graasp/graasp-item-tags:
     eslint-config-prettier: ^8.3.0
     fastify: ^3.29.1
     graasp-item-tags: graasp/graasp-item-tags
-    graasp-test: "github:graasp/graasp-test"
+    graasp-test: "github:graasp/graasp-test#25-item-type"
     husky: 7.0.4
     jest: 27.4.5
     prettier: 2.5.1
-    pretty-quick: 3.1.2
     slonik: 26.1.0
     ts-jest: 27.0.7
     typescript: 4.4.4
@@ -3509,12 +3443,12 @@ graasp-item-tags@graasp/graasp-item-tags:
   languageName: unknown
   linkType: soft
 
-"graasp-test@github:graasp/graasp-test":
+"graasp-test@github:graasp/graasp-test#25-item-type":
   version: 0.1.0
-  resolution: "graasp-test@https://github.com/graasp/graasp-test.git#commit=3ff1f7951d1c2439f84fab546bf8de60b530bd1c"
+  resolution: "graasp-test@https://github.com/graasp/graasp-test.git#commit=2f3a238506012be0da80b5ac899b4e13dd4c887d"
   dependencies:
     uuid: 8.3.2
-  checksum: aaa3759fe2842de03fdc99011623dced835636fe5e15598c8574b9d526c040615dac3bf06fd351007a07d267493f9cd4e70c14ef35b0b73fb2810f90be4bbae8
+  checksum: e4fcc3e4a9434bb590f26610c3d2bdff4f493e4b9257e947eb485649580acbccad4cf100f9335fe1f061b89bbe1209a1bea0ce5d5337af5f1ed6c619915d669f
   languageName: node
   linkType: hard
 
@@ -3636,13 +3570,6 @@ graasp-item-tags@graasp/graasp-item-tags:
   languageName: node
   linkType: hard
 
-"human-signals@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "human-signals@npm:1.1.1"
-  checksum: d587647c9e8ec24e02821b6be7de5a0fc37f591f6c4e319b3054b43fd4c35a70a94c46fc74d8c1a43c47fde157d23acd7421f375e1c1365b09a16835b8300205
-  languageName: node
-  linkType: hard
-
 "human-signals@npm:^2.1.0":
   version: 2.1.0
   resolution: "human-signals@npm:2.1.0"
@@ -3717,10 +3644,17 @@ graasp-item-tags@graasp/graasp-item-tags:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.1.4, ignore@npm:^5.1.8, ignore@npm:^5.2.0":
+"ignore@npm:^5.1.8, ignore@npm:^5.2.0":
   version: 5.2.0
   resolution: "ignore@npm:5.2.0"
   checksum: 6b1f926792d614f64c6c83da3a1f9c83f6196c2839aa41e1e32dd7b8d174cef2e329d75caabb62cb61ce9dc432f75e67d07d122a037312db7caa73166a1bdb77
+  languageName: node
+  linkType: hard
+
+"immutable@npm:4.1.0":
+  version: 4.1.0
+  resolution: "immutable@npm:4.1.0"
+  checksum: b9bc1f14fb18eb382d48339c064b24a1f97ae4cf43102e0906c0a6e186a27afcd18b55ca4a0b63c98eefb58143e2b5ebc7755a5fb4da4a7ad84b7a6096ac5b13
   languageName: node
   linkType: hard
 
@@ -5017,13 +4951,6 @@ graasp-item-tags@graasp/graasp-item-tags:
   languageName: node
   linkType: hard
 
-"mri@npm:^1.1.5":
-  version: 1.2.0
-  resolution: "mri@npm:1.2.0"
-  checksum: 83f515abbcff60150873e424894a2f65d68037e5a7fcde8a9e2b285ee9c13ac581b63cfc1e6826c4732de3aeb84902f7c1e16b7aff46cd3f897a0f757a894e85
-  languageName: node
-  linkType: hard
-
 "ms@npm:2.1.2":
   version: 2.1.2
   resolution: "ms@npm:2.1.2"
@@ -5042,19 +4969,6 @@ graasp-item-tags@graasp/graasp-item-tags:
   version: 0.0.2
   resolution: "multi-fork@npm:0.0.2"
   checksum: bb12ec1c21dd50241e0f565579541222de96e4890140a77794567b266c348f34728ef370053c05a7afd3023357e31e2be7636fdbad31f6aae0fc6f255b81ee81
-  languageName: node
-  linkType: hard
-
-"multimatch@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "multimatch@npm:4.0.0"
-  dependencies:
-    "@types/minimatch": ^3.0.3
-    array-differ: ^3.0.0
-    array-union: ^2.1.0
-    arrify: ^2.0.1
-    minimatch: ^3.0.4
-  checksum: bdb6a98dad4e919d9a1a2a0db872f44fa2337315f2fd5827d91ae005cf22f4425782bdfa97c10b80d567f0cb3c226c31f4e85f8f6a4a4be4facf9af0de1bb0c2
   languageName: node
   linkType: hard
 
@@ -5166,7 +5080,7 @@ graasp-item-tags@graasp/graasp-item-tags:
   languageName: node
   linkType: hard
 
-"npm-run-path@npm:^4.0.0, npm-run-path@npm:^4.0.1":
+"npm-run-path@npm:^4.0.1":
   version: 4.0.1
   resolution: "npm-run-path@npm:4.0.1"
   dependencies:
@@ -5215,7 +5129,7 @@ graasp-item-tags@graasp/graasp-item-tags:
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.0, once@npm:^1.3.1, once@npm:^1.4.0":
+"once@npm:^1.3.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
@@ -5224,7 +5138,7 @@ graasp-item-tags@graasp/graasp-item-tags:
   languageName: node
   linkType: hard
 
-"onetime@npm:^5.1.0, onetime@npm:^5.1.2":
+"onetime@npm:^5.1.2":
   version: 5.1.2
   resolution: "onetime@npm:5.1.2"
   dependencies:
@@ -5671,24 +5585,6 @@ graasp-item-tags@graasp/graasp-item-tags:
   languageName: node
   linkType: hard
 
-"pretty-quick@npm:3.1.2":
-  version: 3.1.2
-  resolution: "pretty-quick@npm:3.1.2"
-  dependencies:
-    chalk: ^3.0.0
-    execa: ^4.0.0
-    find-up: ^4.1.0
-    ignore: ^5.1.4
-    mri: ^1.1.5
-    multimatch: ^4.0.0
-  peerDependencies:
-    prettier: ">=2.0.0"
-  bin:
-    pretty-quick: bin/pretty-quick.js
-  checksum: c4b0de1829c63dfb1c2cb509892410fdba8fd2490b5ef9e1b34c418bc83f9205a7b6559fbf5e349d638e9c0ad1416fb35581d0e3eef2d45ee7093fb0838eaadd
-  languageName: node
-  linkType: hard
-
 "process-warning@npm:^1.0.0":
   version: 1.0.0
   resolution: "process-warning@npm:1.0.0"
@@ -5744,16 +5640,6 @@ graasp-item-tags@graasp/graasp-item-tags:
   version: 1.8.0
   resolution: "psl@npm:1.8.0"
   checksum: 6150048ed2da3f919478bee8a82f3828303bc0fc730fb015a48f83c9977682c7b28c60ab01425a72d82a2891a1681627aa530a991d50c086b48a3be27744bde7
-  languageName: node
-  linkType: hard
-
-"pump@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "pump@npm:3.0.0"
-  dependencies:
-    end-of-stream: ^1.1.0
-    once: ^1.3.1
-  checksum: e42e9229fba14732593a718b04cb5e1cfef8254544870997e0ecd9732b189a48e1256e4e5478148ecb47c8511dca2b09eae56b4d0aad8009e6fac8072923cfc9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR removes tasks running in hooks. It was especially hurtful because they were running in parallel + are only get so it's not really useful to apply transactions here. 
+ run a maximum of parallel queries

close #5 